### PR TITLE
build: fix bee hosts for PR preview

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      REACT_APP_BEE_HOSTS: 'https://api.gateway.ethswarm.org/'
+      REACT_APP_BEE_HOSTS: 'https://gateway-proxy-bee-0-0.gateway.ethswarm.org/,https://gateway-proxy-bee-1-0.gateway.ethswarm.org/,https://gateway-proxy-bee-2-0.gateway.ethswarm.org/,https://gateway-proxy-bee-3-0.gateway.ethswarm.org/,https://gateway-proxy-bee-4-0.gateway.ethswarm.org/,https://gateway-proxy-bee-5-0.gateway.ethswarm.org/,https://gateway-proxy-bee-6-0.gateway.ethswarm.org/,https://gateway-proxy-bee-7-0.gateway.ethswarm.org/,https://gateway-proxy-bee-8-0.gateway.ethswarm.org/,https://gateway-proxy-bee-9-0.gateway.ethswarm.org/'
 
     strategy:
       matrix:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      REACT_APP_BEE_HOSTS: 'https://bee-0.gateway.ethswarm.org/,https://bee-1.gateway.ethswarm.org/,https://bee-2.gateway.ethswarm.org/,https://bee-3.gateway.ethswarm.org/,https://bee-4.gateway.ethswarm.org/,https://bee-5.gateway.ethswarm.org/,https://bee-6.gateway.ethswarm.org/,https://bee-7.gateway.ethswarm.org/,https://bee-8.gateway.ethswarm.org/,https://bee-9.gateway.ethswarm.org/'
+      REACT_APP_BEE_HOSTS: 'https://api.gateway.ethswarm.org/'
 
     strategy:
       matrix:


### PR DESCRIPTION
The `REACT_APP_BEE_HOSTS` environment variable was set to use the old way of addressing gateway modes that is used for the PR previews. This PR fixes it to use the correct url.